### PR TITLE
Support for viewport

### DIFF
--- a/WebPageTestExportPlugin.js
+++ b/WebPageTestExportPlugin.js
@@ -40,6 +40,9 @@ let convert = function (flow) {
       return false;
     }
   }
+  function addViewport(step) {
+    wptScript += `setViewportSize ${step.width} ${step.height}\n`;
+  }
   function addNavigate(url) {
     wptScript += "setEventName Navigate\n";
     wptScript += "navigate " + url + "\n";
@@ -102,6 +105,9 @@ let convert = function (flow) {
   }
   function addScriptLine(step) {
     switch (step.type) {
+      case "setViewport":
+        addViewport(step);
+        break;
       case "navigate":
         addNavigate(step.url);
         break;


### PR DESCRIPTION
Viewport support has been added to WPT scripts. Extension now maps the viewport that is provided by the recorder.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/70441430/185343834-99b3e96a-d6fe-4367-8a5c-7a91d6244fdc.png">

