### PR TITLE
waitForElement, waitForExpression, doubleClick, scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Now you have successfully generated a Webpagetest Custom Script using WEBPAGETES
 - `change` (maps to `execAndWait`)
 - `keydown` (maps to `execAndWait`)
 - `keyup` (maps to `execAndWait`)
+- `waitForElement` (maps to `waitFor`)
+- `waitForExpression` (maps to `waitFor`)
+- `doubleClick` (maps to `execAndWait`)
+- `scroll` (maps to `execAndWait`)
 
 ## Resources
 - [Sample exported script](/REI%20Product%20Flow)


### PR DESCRIPTION
#Added the following events supported by the recorder

- `waitForElement` (maps to `waitFor`)
- `waitForExpression` (maps to `waitFor`)
- `doubleClick` (maps to `execAndWait`)
- `scroll` (maps to `execAndWait`)

https://github.com/WebPageTest/recorder-to-webpagetest-chrome-extension/issues/2